### PR TITLE
feat: user auth tests and refactoring to enable

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -1,24 +1,14 @@
 'use strict';
 
 const LocalStrategy = require('passport-local').Strategy;
-const User = require('../server/User/User').User;
+const UserAuthenticationSvc = require('../server/User/UserAuthenticationSvc');
 
 module.exports = function (passport) {
-    passport.use('create-local-user', new LocalStrategy(
-        function (username, password, done) {
-            User.findOne({'local.username': username}).then(function (err, user) {
-                if(err) { return done(err); }
-                if(user) {
-                    return done(null, false, {message: 'That username is already taken.'});
-                } else {
-                    let newUser = new User();
-                    newUser.createCredentials(username, password);
-                    newUser.save().then(function (err, newUser) {
-                        if(err) { return done(err); }
-                        return done(null, newUser);
-                    });
-                }
-            });
+    passport.use('create-local-user', new LocalStrategy({
+            passReqToCallback: true
+        },
+        function(req, username, password, done) {
+            UserAuthenticationSvc.createNewUser(req, username, password, done);
         }
     ));
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The API for Users of the Realmshaper website.",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --harmony server/**/*Spec.js"
   },
   "repository": {
     "type": "git",

--- a/server/User/User.js
+++ b/server/User/User.js
@@ -11,10 +11,17 @@ let userSchema = new Schema({
     }
 });
 
-userSchema.methods.createCredentials = function (username, password) {
-    this.local.username = username;
-    this.local.password = bcrypt.hashSync(password, 10); //TODO: Think about async?
-};
+userSchema.statics.createUser = function (username, password) {
+    return this.create(
+        {
+            local: {
+                username: username,
+                password: bcrypt.hashSync(password, 10) //TODO: Think about async?
+            }
+        }
+    );
+}
+
 userSchema.methods.validPassword = function (password) {
     return bcrypt.compareSync(password, this.local.password); //TODO: Think about async?
 };

--- a/server/User/UserAuthenticationSvc.js
+++ b/server/User/UserAuthenticationSvc.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const User = require('./User').User;
+
+function createNewUser(req, username, password, done) {
+    User.findOne({'local.username': username})
+        .then(function (user) {
+            if(user) {
+                return done(null, false, req.flash('signupMessage', 'That username is already taken.'));
+            } else {
+                User.createUser(username, password)
+                    .then(function (newUser) {
+                        return done(null, newUser);
+                    })
+                    .catch(function (err) {
+                        return done(err);
+                    });
+            }
+        })
+        .catch(function (err) {
+            return done(err);
+        });
+}
+
+exports.createNewUser = createNewUser;

--- a/server/User/UserAuthenticationSvcSpec.js
+++ b/server/User/UserAuthenticationSvcSpec.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/* EXTERNAL DEPENDENCIES */
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const Bluebird = require('bluebird');
+require('sinon-as-promised')(Bluebird);
+const mongoose = require('mongoose');
+
+/* INTERNAL DEPENDENCIES */
+const UserAuthenticationSvc = require('./UserAuthenticationSvc');
+const User = require('./User').User;
+
+describe('#UserAuthenticationSvc', function () {
+    describe('#createNewUser', function () {
+
+        let _findOne,
+            _createUser,
+            _done;
+
+        let testNewUser = {
+            username: 'testuser',
+            password: 'testpass'
+        };
+
+        let testExistingUser = {
+            _id: 'test',
+            local: {
+                username: 'testexistingname',
+                password: 'testexistingpassword'
+            }
+        };
+
+        let _req = {
+            flash: function () {}
+        };
+
+        beforeEach(function () {
+            _findOne = sinon.stub(User, 'findOne');
+            _createUser = sinon.stub(User, 'createUser');
+            _done = sinon.spy();
+        });
+
+        afterEach(function () {
+            User.findOne.restore();
+            User.createUser.restore();
+        });
+
+        it('should create a new user if none are found by \"User.findOne()\"', function testUserCreation() {
+            _findOne.resolves(null);
+            _createUser.resolves(testNewUser);
+            UserAuthenticationSvc.createNewUser(_req, 'testuser', 'testpass', _done);
+            expect(_findOne).to.be.calledWith({'local.username': 'testuser'});
+            return _findOne().then(function () {
+                expect(_createUser).to.be.calledWith('testuser', 'testpass');
+                return _createUser().then(function () {
+                    expect(_done).to.be.calledWith(null, testNewUser);
+                });
+            });
+        });
+
+        it('should fail properly when the new user save causes an error', function testUserSaveFailure() {
+            _findOne.resolves(null);
+            _createUser.rejects('This fails terribly!');
+            UserAuthenticationSvc.createNewUser(_req, 'testuser', 'testpass', _done);
+            expect(_findOne).to.be.calledWith({'local.username': 'testuser'});
+            return _findOne().then(function () {
+                expect(_createUser).to.be.calledWith('testuser', 'testpass');
+                return _createUser().catch(function () {
+                    expect(_done).to.be.calledWith(new Error('This fails terribly!'));
+                });
+            });
+        });
+
+        it('should fail properly if \"User.findOne()\" returns a User', function testUserFound() {
+            _findOne.resolves(testExistingUser);
+            UserAuthenticationSvc.createNewUser(_req, 'testuser', 'testpass', _done);
+            expect(_findOne).to.be.calledWith({'local.username': 'testuser'});
+            return _findOne().then(function () {
+                expect(_done).to.be.calledWith(null, false, _req.flash('signupMessage', 'That username is already taken.'));
+            });
+        });
+
+        it('should fail properly when \"User.findOne()\" errors out', function testUserFindError() {
+            _findOne.rejects('This fails terribly!');
+            UserAuthenticationSvc.createNewUser(_req, 'testuser', 'testpass', _done);
+            expect(_findOne).to.be.calledWith({'local.username': 'testuser'});
+            return _findOne().catch(function () {
+                expect(_done).to.be.calledWith(new Error('This fails terribly!'));
+            });
+        });
+
+    });
+});

--- a/server/User/UserRoutes.js
+++ b/server/User/UserRoutes.js
@@ -3,7 +3,11 @@
 module.exports = function (app, passport) {
     app.get('/api/users', function (req, res) {}); // users (GET) [ADMIN; "See All Users"]
     app.get('/api/users/:user_id', function (req, res) {}); // users/user_id (GET) [ADMIN/User; "See Profile"]
-    app.post('/api/users', passport.authenticate('create-local-user', {failureFlash: true})); // users (POST) [ALL; "Sign-up"]
+    app.post('/api/users', passport.authenticate('create-local-user', {failureFlash: true, session: false}), function (req, res) {
+        res.json({
+            message: 'New User created!'
+        });
+    }); // users (POST) [ALL; "Sign-up"]
     app.put('/api/users/:user_id', function (req, res) {}); // users/user_id (PUT) [ADMIN/User; "Edit Profile"]
     app.delete('/api/users/:user_id', function (req, res) {}); // users/user_id (DLETE) [ADMIN/User; "Delete Profile"]
     app.post('/api/permitted-users', function (req, res) {}); // login a given user


### PR DESCRIPTION
Refactor User so that its methods are easily mockable
Add UserAuthenticationSvc to move passport User creation and auth methods out of config file
Add UserAuthenticationSvcSpec to test authentication methods used by Passport
Update UserRoutes to reflect when passport middleware is successful
Add tests for all paths during createNewUser
